### PR TITLE
fix: ACNA-1727 - modify action generator templates so it fails when config options are not set

### DIFF
--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -23,7 +23,7 @@ class ActionGenerator extends Generator {
     // required
     this.option('action-folder', { type: String, description: 'relative path to the action folder' })
     this.option('config-path', { type: String, description: 'relative path to the config yaml file' })
-    this.option('full-key-to-manifest', { type: String, default: '' }) // key in config path that resolves to manifest e.g. 'application.runtimeManifest'
+    this.option('full-key-to-manifest', { type: String, description: 'key in config path that resolves to manifest e.g. "application.runtimeManifest"', default: '' })
 
     if (!(this.options['action-folder'] && this.options['config-path'])) {
       this.env.error(`One or more options are missing for this generator. \nUsage:\n${this.optionsHelp()}`)

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -21,13 +21,18 @@ class ActionGenerator extends Generator {
     super(args, opts)
     this.option('skip-prompt', { default: false }) // prompt to ask action name
     // required
-    this.option('action-folder', { type: String })
-    this.option('config-path', { type: String })
+    this.option('action-folder', { type: String, description: 'relative path to the action folder' })
+    this.option('config-path', { type: String, description: 'relative path to the config yaml file' })
     this.option('full-key-to-manifest', { type: String, default: '' }) // key in config path that resolves to manifest e.g. 'application.runtimeManifest'
+
+    if (!(this.options['action-folder'] && this.options['config-path'])) {
+      this.env.error(`One or more options are missing for this generator. \nUsage:\n${this.optionsHelp()}`)
+    }
 
     // path to store action and runtime config
     this.actionFolder = this.options['action-folder'] // todo ensure this is relative to root
     this.configPath = this.destinationPath(this.options['config-path'])
+
     this.fullKeyToManifest = this.options['full-key-to-manifest']
     // load manifest and package name
     this.defaultRuntimePackageName = path.basename(path.dirname(this.configPath)) // todo do better, allow to pass in package name ?

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -44,6 +44,9 @@ describe('implementation', () => {
   beforeEach(() => {
     ActionGenerator.prototype.templatePath = p => path.join('/fakeTplDir', p)
     ActionGenerator.prototype.destinationPath = (...args) => path.join('/fakeDestRoot', ...args)
+    ActionGenerator.prototype.env = {
+      error: (text) => { throw text }
+    }
     Generator.prototype.options = generatorOptions
   })
   describe('constructor', () => {
@@ -52,10 +55,16 @@ describe('implementation', () => {
       // eslint-disable-next-line no-new
       new ActionGenerator()
       expect(spy).toHaveBeenCalledWith('skip-prompt', { default: false })
-      expect(spy).toHaveBeenCalledWith('action-folder', { type: String })
-      expect(spy).toHaveBeenCalledWith('config-path', { type: String })
-      expect(spy).toHaveBeenCalledWith('full-key-to-manifest', { type: String, default: '' })
+      expect(spy).toHaveBeenCalledWith('action-folder', { type: String, description: expect.any(String) })
+      expect(spy).toHaveBeenCalledWith('config-path', { type: String, description: expect.any(String) })
+      expect(spy).toHaveBeenCalledWith('full-key-to-manifest', { type: String, description: expect.any(String), default: '' })
       spy.mockRestore()
+    })
+
+    test('no options', () => {
+      Generator.prototype.options = {} // no options set, should error
+      // eslint-disable-next-line no-new
+      expect(() => new ActionGenerator()).toThrowError()
     })
   })
   describe('promptForActionName', () => {


### PR DESCRIPTION
## Motivation and Context

Action generators that have required options should fail if required options are not provided.

## How Has This Been Tested?

- npm test
- cli test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
