### PR TITLE
skip prompt to have no effect for events generator

### DIFF
--- a/lib/EventsGenerator.js
+++ b/lib/EventsGenerator.js
@@ -53,33 +53,31 @@ class EventsGenerator extends ActionGenerator {
   }
 
   async promptForEventsDetails (defaultValues, options) {
-    if (!this.options['skip-prompt']) {
-      const eventsClient = await this.initEventsClient()
-      const runtimeActionName = await promptForRuntimeAction(this)
-      let regName = defaultValues.regName
-      let regDesc = defaultValues.regDesc
+    const eventsClient = await this.initEventsClient()
+    const runtimeActionName = await promptForRuntimeAction(this)
+    let regName = defaultValues.regName
+    let regDesc = defaultValues.regDesc
 
-      const basicDetails = await this.prompt([
-        {
-          type: 'input',
-          name: 'regName',
-          message: 'We are about to create a new Event registration.\nHow would you like to name this registration?',
-          default: regName,
-          when: !this.options['skip-prompt']
-        },
-        {
-          type: 'input',
-          name: 'regDesc',
-          message: 'What is this registration being created for?',
-          default: regDesc,
-          when: !this.options['skip-prompt']
-        }
-      ])
-      regName = basicDetails.regName
-      regDesc = basicDetails.regDesc
-      const selectedProvidersToEventMetadata = await promptForEventsOfInterest(eventsClient, this, options)
-      return { regName, regDesc, selectedProvidersToEventMetadata, runtimeActionName }
-    }
+    const basicDetails = await this.prompt([
+      {
+        type: 'input',
+        name: 'regName',
+        message: 'We are about to create a new Event registration.\nHow would you like to name this registration?',
+        default: regName,
+        when: !this.options['skip-prompt']
+      },
+      {
+        type: 'input',
+        name: 'regDesc',
+        message: 'What is this registration being created for?',
+        default: regDesc,
+        when: !this.options['skip-prompt']
+      }
+    ])
+    regName = basicDetails.regName
+    regDesc = basicDetails.regDesc
+    const selectedProvidersToEventMetadata = await promptForEventsOfInterest(eventsClient, this, options)
+    return { regName, regDesc, selectedProvidersToEventMetadata, runtimeActionName }
   }
 
   /**

--- a/test/lib/EventGenerator.test.js
+++ b/test/lib/EventGenerator.test.js
@@ -145,7 +145,7 @@ describe('implementation', () => {
       expect(regDetails.runtimeActionName).toContain('test-action-name')
     })
 
-    test('skip prompt for event details', async () => {
+    test('skip prompt for event details to have no effect', async () => {
       eventsGenerator.options = { 'skip-prompt': true }
       promptSpy.mockResolvedValue({
         regName: 'test-name',
@@ -153,7 +153,9 @@ describe('implementation', () => {
       })
       const regDetails = await eventsGenerator.promptForEventsDetails({ regName: 'defaultName', regDesc: 'defaultDesc' })
       // { regName, regDesc, selectedProvidersToEventMetadata, runtimeActionName }
-      expect(regDetails).toBeUndefined()
+      expect(regDetails.regName).toContain('test-name')
+      expect(regDetails.regDesc).toContain('test-description')
+      expect(regDetails.runtimeActionName).toContain('test-action-name')
     })
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Skip prompt will have no effect on events generator since there can be no default values that can be set for an events registration

## Related Issue

https://github.com/adobe/generator-app-common-lib/issues/38

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
