### PR TITLE
Events to be added under the extension in app.config.yaml using events-config-path option

### DIFF
--- a/lib/EventsGenerator.js
+++ b/lib/EventsGenerator.js
@@ -27,14 +27,15 @@ class EventsGenerator extends ActionGenerator {
     // required
     this.option('config-path',
       { type: String, description: 'relative path to the config yaml file' })
+    this.option('events-config-path',
+      { type: String, description: 'relative path to the events config yaml file' })
     this.option('full-key-to-events-manifest', {
       type: String,
       description: 'key in config path that resolves to events manifest e.g. "application.events"',
       default: ''
     })
-
-    this.configPath = this.destinationPath(this.options['config-path'])
-    this.fullKeyToRuntimeManifest = this.options['full-key-to-manifest']
+    this.runtimeConfigPath = this.destinationPath(this.options['config-path'])
+    this.eventsConfigPath = this.destinationPath(this.options['events-config-path'])
     this.actionFolder = this.options['action-folder'] // todo ensure this is relative to root
     this.fullKeyToEventsManifest = this.options['full-key-to-events-manifest']
     this.projectConfig = config.get('project')
@@ -98,24 +99,24 @@ class EventsGenerator extends ActionGenerator {
     if (!eventDetails) {
       return
     }
-    const events = this.loadEventsManifest(this.configPath,
+    const events = this.loadEventsManifest(this.eventsConfigPath,
       this.fullKeyToEventsManifest)
     const { runtimeManifest, runtimePackageName } = this.loadRuntimeManifest(
-      this.configPath, this.fullKeyToManifest,
+      this.runtimeConfigPath, this.fullKeyToManifest,
       this.defaultRuntimePackageName)
     if (!runtimeManifest.packages[runtimePackageName].actions[eventDetails.runtimeActionName]) {
       this.addAction(eventDetails.runtimeActionName, tplActionPath, options)
     }
     this.setEventsManifestDetails(eventDetails, events, runtimePackageName)
-    this.writeEventsManifest(this.configPath, this.fullKeyToEventsManifest,
+    this.writeEventsManifest(this.eventsConfigPath, this.fullKeyToEventsManifest,
       events)
     const mapping = this.setDotEnvFileDetails(eventDetails)
     this.writeDotEnvFile(mapping)
   }
 
   /** @private */
-  loadEventsManifest (configPath, fullKeyToEventsManifest) {
-    const config = utils.readYAMLConfig(this, configPath)
+  loadEventsManifest (eventsConfigPath, fullKeyToEventsManifest) {
+    const config = utils.readYAMLConfig(this, eventsConfigPath)
     let events = fullKeyToEventsManifest.split('.').reduce((obj, k) => obj && obj[k], config) || {}
     if (!events.registrations) {
       events = {
@@ -126,8 +127,8 @@ class EventsGenerator extends ActionGenerator {
   }
 
   /** @private */
-  writeEventsManifest (configPath, fullKeyToEventsManifest, events) {
-    utils.writeKeyYAMLConfig(this, configPath, fullKeyToEventsManifest, events)
+  writeEventsManifest (eventsConfigPath, fullKeyToEventsManifest, events) {
+    utils.writeKeyYAMLConfig(this, eventsConfigPath, fullKeyToEventsManifest, events)
   }
 
   /** @private */

--- a/lib/events/RuntimeActionForEventsHelper.js
+++ b/lib/events/RuntimeActionForEventsHelper.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 async function promptForRuntimeAction (obj) {
   const { runtimeManifest, runtimePackageName } = obj.loadRuntimeManifest(
-    obj.configPath, obj.fullKeyToManifest, obj.defaultRuntimePackageName)
+    obj.runtimeConfigPath, obj.fullKeyToManifest, obj.defaultRuntimePackageName)
   const existingActions = getExistingActionNames(runtimeManifest, runtimePackageName)
   let runtimeActionName
   if (existingActions.length > 0) {

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -37,8 +37,9 @@ global.assertNodeEngines = (fs, nodeEngines) => {
   }))
 }
 global.basicGeneratorOptions = {
-  'action-folder': 'actions',
-  'config-path': 'ext.config.yaml',
+  'action-folder': 'src/dx-excshell-1/actions',
+  'config-path': 'src/dx-excshell-1/ext.config.yaml',
+  'events-config-path': 'app.config.yaml',
   'full-key-to-manifest': 'runtimeManifest',
-  'full-key-to-events-manifest': 'events'
+  'full-key-to-events-manifest': 'extensions.dx/excshell/1.events'
 }

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -40,6 +40,7 @@ beforeEach(() => {
   utils.writeKeyYAMLConfig.mockRestore()
 })
 
+const actionFolderPath = `src/dx-excshell-1/${constants.actionsDirname}`
 describe('implementation', () => {
   beforeEach(() => {
     ActionGenerator.prototype.templatePath = p => path.join('/fakeTplDir', p)
@@ -183,14 +184,14 @@ Note: characters can only be split by '-'.
       actionGenerator.addAction('myAction', './templateFile.js')
 
       // 1. test copy action template to right destination
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${constants.actionsDirname}/myAction/index.js`), {}, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${actionFolderPath}/myAction/index.js`), {}, {}, {})
       // 2. test manifest creation with action information
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         actionGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
+        n('/fakeDestRoot/src/dx-excshell-1/ext.config.yaml'),
         'runtimeManifest',
         // function path should be checked to be relative to config file
-        { packages: { fakeDestRoot: { actions: { myAction: { annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), runtime: constants.defaultRuntimeKind, web: 'yes' } }, license: 'Apache-2.0' } } })
+        { packages: { 'dx-excshell-1': { actions: { myAction: { annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), runtime: constants.defaultRuntimeKind, web: 'yes' } }, license: 'Apache-2.0' } } })
 
       // 3. make sure wskdebug dev dependency was added to package.json
       expect(utils.addDependencies).toHaveBeenCalledWith(actionGenerator, { '@openwhisk/wskdebug': expect.any(String) }, true)
@@ -202,10 +203,9 @@ Note: characters can only be split by '-'.
       utils.readYAMLConfig.mockReturnValue({
         runtimeManifest: {
           packages: {
-            somepackage: {
+            'dx-excshell-1': {
               actions: {
                 actionxyz: { function: 'fake.js' }
-
               }
             }
           }
@@ -215,14 +215,14 @@ Note: characters can only be split by '-'.
       actionGenerator.addAction('myAction', './templateFile.js', { dependencies: { abc: '1.2.3', def: '4.5.6' }, devDependencies: { xyz: '3.2.1', vuw: '6.5.4' } })
 
       // 1. test copy action template to right destination
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${constants.actionsDirname}/myAction/index.js`), {}, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${actionFolderPath}/myAction/index.js`), {}, {}, {})
       // 2. test manifest creation with action information, and preserving previous content
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         actionGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
+        n('/fakeDestRoot/src/dx-excshell-1/ext.config.yaml'),
         'runtimeManifest',
         // function path should be checked to be relative to config file
-        { packages: { somepackage: { actions: { actionxyz: { function: 'fake.js' }, myAction: { annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), runtime: constants.defaultRuntimeKind, web: 'yes' } } } } })
+        { packages: { 'dx-excshell-1': { actions: { actionxyz: { function: 'fake.js' }, myAction: { annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), runtime: constants.defaultRuntimeKind, web: 'yes' } } } } })
       // 3. make sure wskdebug dev dependency was added to package.json
       // prod
       expect(utils.addDependencies).toHaveBeenCalledWith(actionGenerator, {
@@ -244,7 +244,7 @@ Note: characters can only be split by '-'.
       actionGenerator.addAction('myAction', './templateFile.js', { tplContext: { fake: 'context', with: { fake: 'values' } } })
 
       // 1. test copy action template to right destination with template options
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${constants.actionsDirname}/myAction/index.js`), { fake: 'context', with: { fake: 'values' } }, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${actionFolderPath}/myAction/index.js`), { fake: 'context', with: { fake: 'values' } }, {}, {})
     })
 
     test('with tplContext option and actionDestPath already set and no maniifest', () => {
@@ -255,7 +255,7 @@ Note: characters can only be split by '-'.
       actionGenerator.addAction('myAction', './templateFile.js', { tplContext: { actionDestPath: `${path.sep}fakeDestRoot${path.sep}${constants.actionsDirname}${path.sep}myAction${path.sep}index.js`, fake: 'context', with: { fake: 'values' } } })
 
       // 1. test copy action template to predefined destination
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${constants.actionsDirname}${path.sep}myAction${path.sep}index.js`), { actionDestPath: `${path.sep}fakeDestRoot${path.sep}${constants.actionsDirname}${path.sep}myAction${path.sep}index.js`, fake: 'context', with: { fake: 'values' } }, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templateFile.js'), n(`${actionFolderPath}${path.sep}myAction${path.sep}index.js`), { actionDestPath: `${path.sep}fakeDestRoot${path.sep}${constants.actionsDirname}${path.sep}myAction${path.sep}index.js`, fake: 'context', with: { fake: 'values' } }, {}, {})
     })
 
     test('with extra actionManifestConfig and no manifest', () => {
@@ -267,10 +267,10 @@ Note: characters can only be split by '-'.
       // test manifest creation with action information
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         actionGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
+        n('/fakeDestRoot/src/dx-excshell-1/ext.config.yaml'),
         'runtimeManifest',
         // function path should be checked to be relative to config file
-        { packages: { fakeDestRoot: { actions: { myAction: { runtime: 'fake:42', inputs: { fake: 'value' }, annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), web: 'yes' } }, license: 'Apache-2.0' } } })
+        { packages: { 'dx-excshell-1': { actions: { myAction: { runtime: 'fake:42', inputs: { fake: 'value' }, annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), web: 'yes' } }, license: 'Apache-2.0' } } })
     })
 
     test('with dotenvStub option', () => {
@@ -289,7 +289,7 @@ Note: characters can only be split by '-'.
 
       actionGenerator.addAction('myAction', './templateFile.js', { testFile: './template.test.js' })
       expect(actionGenerator.fs.copyTpl).toHaveBeenCalledTimes(2)
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/template.test.js'), n('/fakeDestRoot/test/myAction.test.js'), { actionRelPath: expect.stringContaining('myAction/index.js') }, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/template.test.js'), n('/fakeDestRoot/src/dx-excshell-1/test/myAction.test.js'), { actionRelPath: expect.stringContaining('myAction/index.js') }, {}, {})
     })
 
     test('with testFile option and tplContext option', () => {
@@ -300,7 +300,7 @@ Note: characters can only be split by '-'.
       actionGenerator.addAction('myAction', './templateFile.js', { testFile: './template.test.js', tplContext: { fake: 'context', with: { fake: 'values' } } })
 
       expect(actionGenerator.fs.copyTpl).toHaveBeenCalledTimes(2)
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/template.test.js'), n('/fakeDestRoot/test/myAction.test.js'), { actionRelPath: expect.stringContaining('myAction/index.js'), fake: 'context', with: { fake: 'values' } }, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/template.test.js'), n('/fakeDestRoot/src/dx-excshell-1/test/myAction.test.js'), { actionRelPath: expect.stringContaining('myAction/index.js'), fake: 'context', with: { fake: 'values' } }, {}, {})
     })
 
     test('with e2eTestFile option', () => {
@@ -310,7 +310,7 @@ Note: characters can only be split by '-'.
 
       actionGenerator.addAction('myAction', './templateFile.js', { e2eTestFile: './templatee2e.test.js' })
       expect(actionGenerator.fs.copyTpl).toHaveBeenCalledTimes(2)
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templatee2e.test.js'), n('/fakeDestRoot/e2e/myAction.e2e.test.js'), { runtimePackageName: 'fakeDestRoot' }, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/templatee2e.test.js'), n('/fakeDestRoot/src/dx-excshell-1/e2e/myAction.e2e.test.js'), { runtimePackageName: 'dx-excshell-1' }, {}, {})
     })
 
     test('with sharedLibFile option', () => {
@@ -320,7 +320,7 @@ Note: characters can only be split by '-'.
 
       actionGenerator.addAction('myAction', './templateFile.js', { sharedLibFile: './utils.js' })
 
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/utils.js'), n(`/fakeDestRoot/${constants.actionsDirname}/utils.js`), {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/utils.js'), n(`/fakeDestRoot/${actionFolderPath}/utils.js`), {})
     })
 
     test('with sharedLibTestFile option', () => {
@@ -330,7 +330,7 @@ Note: characters can only be split by '-'.
 
       actionGenerator.addAction('myAction', './templateFile.js', { sharedLibTestFile: './utils.test.js' })
 
-      expect(actionGenerator.fs.copyTpl).not.toHaveBeenCalledWith(n('/fakeTplDir/utils.test.js'), n(`/fakeDestRoot/test/${constants.actionsDirname}/utils.test.js`), {})
+      expect(actionGenerator.fs.copyTpl).not.toHaveBeenCalledWith(n('/fakeTplDir/utils.test.js'), n(`/fakeDestRoot/src/dx-excshell-1/test/${constants.actionsDirname}/utils.test.js`), {})
     })
 
     test('with sharedLibFile and sharedLibTestFile option', () => {
@@ -341,9 +341,10 @@ Note: characters can only be split by '-'.
       actionGenerator.addAction('myAction', './templateFile.js', { sharedLibFile: './utils.js', sharedLibTestFile: './utils.test.js' })
       expect(actionGenerator.fs.copyTpl).toHaveBeenCalled()
 
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/utils.js'), n(`/fakeDestRoot/${constants.actionsDirname}/utils.js`), {})
-      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/utils.test.js'), n('/fakeDestRoot/test/utils.test.js'), { utilsRelPath: expect.stringContaining('../actions/utils.js') }, {}, {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/utils.js'), n(`/fakeDestRoot/${actionFolderPath}/utils.js`), {})
+      expect(actionGenerator.fs.copyTpl).toHaveBeenCalledWith(n('/fakeTplDir/utils.test.js'), n('/fakeDestRoot/src/dx-excshell-1/test/utils.test.js'), { utilsRelPath: expect.stringContaining('../actions/utils.js') }, {}, {})
     })
+
     test('with existing package.json node engines', () => {
       // mock files
       utils.readPackageJson.mockReturnValue({ engines: { node: '1 || 2' } })

--- a/test/lib/EventGenerator.test.js
+++ b/test/lib/EventGenerator.test.js
@@ -191,7 +191,17 @@ describe('implementation', () => {
       getProviderMetadataToProvidersExistingMap.mockImplementation(() => {})
       utils.readPackageJson.mockReturnValue({})
       utils.readYAMLConfig.mockReturnValue({})
-
+      eventsGenerator.loadRuntimeManifest.mockReturnValue({
+        runtimeManifest: {
+          packages: {
+            'dx-excshell-1': {
+              license: 'Apache-2.0',
+              actions: {}
+            }
+          }
+        },
+        runtimePackageName: 'dx-excshell-1'
+      })
       eventsGenerator.addEvents(
         mockData.data.eventDetailsInput
       )
@@ -211,6 +221,30 @@ describe('implementation', () => {
       // mock files
       getProviderMetadataToProvidersExistingMap.mockReturnValueOnce({ 'provider-metadata-3': 'provider-3' })
       utils.readPackageJson.mockReturnValue({})
+      eventsGenerator.loadRuntimeManifest.mockReturnValue({
+        runtimeManifest: {
+          packages: {
+            'dx-excshell-1': {
+              license: 'Apache-2.0',
+              actions: {
+                'test-action-name-existing': {
+                  function: 'actions/generic/index.js',
+                  web: 'yes',
+                  runtime: 'nodejs:16',
+                  inputs: {
+                    LOG_LEVEL: 'debug'
+                  },
+                  annotations: {
+                    'require-adobe-auth': true,
+                    final: true
+                  }
+                }
+              }
+            }
+          }
+        },
+        runtimePackageName: 'dx-excshell-1'
+      })
       utils.readYAMLConfig.mockReturnValue({
         extensions: {
           'dx/excshell/1': {
@@ -247,6 +281,30 @@ describe('implementation', () => {
     test('with events manifest already exists and updating existing registration', () => {
       getProviderMetadataToProvidersExistingMap.mockReturnValueOnce({ 'provider-metadata-3': 'provider-id-3' })
       utils.readPackageJson.mockReturnValue({})
+      eventsGenerator.loadRuntimeManifest.mockReturnValue({
+        runtimeManifest: {
+          packages: {
+            'dx-excshell-1': {
+              license: 'Apache-2.0',
+              actions: {
+                'test-action-name-prev': {
+                  function: 'actions/generic/index.js',
+                  web: 'yes',
+                  runtime: 'nodejs:16',
+                  inputs: {
+                    LOG_LEVEL: 'debug'
+                  },
+                  annotations: {
+                    'require-adobe-auth': true,
+                    final: true
+                  }
+                }
+              }
+            }
+          }
+        },
+        runtimePackageName: 'dx-excshell-1'
+      })
       utils.readYAMLConfig.mockReturnValue({
         events: {
           registrations: {

--- a/test/lib/EventGenerator.test.js
+++ b/test/lib/EventGenerator.test.js
@@ -63,6 +63,8 @@ describe('prototype', () => {
   })
 })
 
+const eventsKey = 'extensions.dx/excshell/1.events'
+const eventsDataPath = '/fakeDestRoot/app.config.yaml'
 describe('implementation', () => {
   beforeEach(() => {
     EventsGenerator.prototype.templatePath = p => path.join('/fakeTplDir', p)
@@ -81,6 +83,7 @@ describe('implementation', () => {
       expect(spy).toHaveBeenCalledWith('skip-prompt', { default: false })
       expect(spy).toHaveBeenCalledWith('action-folder', { type: String, description: expect.any(String) })
       expect(spy).toHaveBeenCalledWith('config-path', { type: String, description: expect.any(String) })
+      expect(spy).toHaveBeenCalledWith('events-config-path', { type: String, description: expect.any(String) })
       expect(spy).toHaveBeenCalledWith('full-key-to-manifest', { type: String, description: expect.any(String), default: '' })
       expect(spy).toHaveBeenCalledWith('full-key-to-events-manifest', { type: String, description: expect.any(String), default: '' })
 
@@ -165,6 +168,7 @@ describe('implementation', () => {
       eventsGenerator = new EventsGenerator()
       eventsGenerator.options = { 'skip-prompt': false }
       eventsGenerator.addAction = jest.fn()
+      eventsGenerator.loadRuntimeManifest = jest.fn()
     })
 
     test('with no options and manifest does not exist and no regDetails', () => {
@@ -194,8 +198,8 @@ describe('implementation', () => {
       // 1. test manifest creation with action information
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         eventsGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
-        'events',
+        n(eventsDataPath),
+        eventsKey,
         // function path should be checked to be relative to config file
         mockData.data.eventsManifestDetails)
       // 2. check if the env variable file is updated with right values
@@ -208,20 +212,25 @@ describe('implementation', () => {
       getProviderMetadataToProvidersExistingMap.mockReturnValueOnce({ 'provider-metadata-3': 'provider-3' })
       utils.readPackageJson.mockReturnValue({})
       utils.readYAMLConfig.mockReturnValue({
-        events: {
-          registrations: {
-            'test-name-existing': mockData.data.existingTestRegistration
+        extensions: {
+          'dx/excshell/1': {
+            $include: 'src/dx-excshell-1/ext.config.yaml',
+            events: {
+              registrations: {
+                'test-name-existing': mockData.data.existingTestRegistration
+              }
+            }
           }
         }
       })
 
       eventsGenerator.addEvents(mockData.data.eventDetailsInput, './templateFile.js')
 
-      // 1. test manifest creation with action information, and preserving previous content
+      // 1. test manifest creation with events information, and preserving previous content
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         eventsGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
-        'events',
+        n(eventsDataPath),
+        eventsKey,
         // function path should be checked to be relative to config file
         {
           registrations: {
@@ -256,8 +265,8 @@ describe('implementation', () => {
       // 1. test manifest creation with action information, and preserving previous content
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         eventsGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
-        'events',
+        n(eventsDataPath),
+        eventsKey,
         // function path should be checked to be relative to config file
         {
           registrations: {
@@ -272,23 +281,44 @@ describe('implementation', () => {
 
     test('with events manifest already exists and with new registration but same events of interest and existing runtime action', () => {
       getProviderMetadataToProvidersExistingMap.mockReturnValueOnce({ 'provider-metadata-3': 'provider-id-3' })
-      utils.readPackageJson.mockReturnValue({})
-      utils.readYAMLConfig.mockReturnValue({
+      eventsGenerator.loadRuntimeManifest.mockReturnValue({
         runtimeManifest: {
           packages: {
-            somepackage: {
+            'dx-excshell-1': {
+              license: 'Apache - 2.0',
               actions: {
-                'test-action-name-existing': { function: 'fake.js' }
+                'test-action-name-existing': {
+                  function: 'actions/generic/index.js',
+                  web: 'yes',
+                  runtime: 'nodejs:16',
+                  inputs: {
+                    LOG_LEVEL: 'debug'
+                  },
+                  annotations: {
+                    'require-adobe-auth': true,
+                    final: true
+                  }
+                }
               }
             }
           }
         },
-        events: {
-          registrations: {
-            'test-name-existing': mockData.data.existingTestRegistration
-          }
-        }
+        runtimePackageName: 'dx-excshell-1'
       })
+      utils.readPackageJson.mockReturnValue({})
+      utils.readYAMLConfig
+        .mockReturnValueOnce({
+          extensions: {
+            'dx/excshell/1': {
+              $include: 'src/dx-excshell-1/ext.config.yaml',
+              events: {
+                registrations: {
+                  'test-name-existing': mockData.data.existingTestRegistration
+                }
+              }
+            }
+          }
+        })
 
       eventsGenerator.addEvents({
         regName: mockData.data.eventDetailsInput.regName,
@@ -317,8 +347,8 @@ describe('implementation', () => {
       // 1. test manifest creation with action information, and preserving previous content
       expect(utils.writeKeyYAMLConfig).toHaveBeenCalledWith(
         eventsGenerator,
-        n('/fakeDestRoot/ext.config.yaml'),
-        'events',
+        n(eventsDataPath),
+        eventsKey,
         // function path should be checked to be relative to config file
         {
           registrations: {

--- a/test/lib/mock.js
+++ b/test/lib/mock.js
@@ -73,7 +73,7 @@ const testRegistration = {
       provider_metadata: 'provider-metadata-2'
     }
   ],
-  runtime_action: 'fakeDestRoot/test-action-name'
+  runtime_action: 'dx-excshell-1/test-action-name'
 }
 
 const existingTestRegistration = {
@@ -87,7 +87,7 @@ const existingTestRegistration = {
       provider_metadata: 'provider-metadata-3'
     }
   ],
-  runtime_action: 'somepackage/test-action-name-existing'
+  runtime_action: 'dx-excshell-1/test-action-name-existing'
 }
 
 const eventsManifestDetails = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use events-config-path which will add event registrations to the app config file and not in the same file as the runtime Manifest. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
