### PR TITLE
Filter and show only those providers that have valid event metadata on provider selection

### DIFF
--- a/lib/events/EventsOfInterestHelper.js
+++ b/lib/events/EventsOfInterestHelper.js
@@ -9,16 +9,23 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { selectEventMetadataForProvider, selectProviderForProviderMetadata } = require('./ProviderHelper')
+const { getAllEntitledProvidersForOrg, selectEventMetadataForProvider, selectProviderForProviderMetadata } = require('./ProviderHelper')
 const { getEntitledProviderMetadataForOrg, getProviderMetadata } = require('./ProviderMetadataHelper')
 
 async function promptForEventsOfInterest (eventsClient, obj, options) {
+  // get all entitled provider metadata for the org
   const providerMetadataList = await getEntitledProviderMetadataForOrg(eventsClient)
-  // get all providers filtered by the selected provider metadata ids
-  const providerMetadataIds = await getProviderMetadata(obj, providerMetadataList, options)
-  // get a map of provider_metadata_id -> providers
-  const providerMetadataToProvidersMap = await getProviderMetadataToProvidersMap(obj.projectConfig.org.id, eventsClient, providerMetadataIds)
-  // get the existing map of provider_metadata_id -> provider_id from the .env file
+  // get all entitled providers for the org
+  const allProvidersForOrgList = await getAllEntitledProvidersForOrg(eventsClient, obj.projectConfig.org.id)
+  // get a map of provider_metadata_id -> List of providers with valid event metadata
+  const providerMetadataToProvidersMap = getProviderMetadataToProvidersMap(obj.projectConfig.org.id, eventsClient, allProvidersForOrgList)
+  // filter provider metadata that do not have associated providers
+  const filteredProviderMetadataList = filterProviderMetadataWithInvalidProviders(providerMetadataList,
+    providerMetadataToProvidersMap)
+  // get user selected provider metadata ids
+  const providerMetadataIds = await getProviderMetadata(obj, filteredProviderMetadataList, options)
+
+  // get user selected providers and associated event metadata
   const selectedProvidersToEventMetadata = new Map()
   for (const providerMetadataId of providerMetadataIds) {
     const providerSelected = await selectProviderForProviderMetadata(
@@ -34,26 +41,35 @@ async function promptForEventsOfInterest (eventsClient, obj, options) {
   return selectedProvidersToEventMetadata
 }
 
-/** @private */
-async function getProviderMetadataToProvidersMap (consumerId, eventsClient, providerMetadataIds) {
-  const providersHalModel = await eventsClient.getAllProviders(consumerId, {
-    fetchEventMetadata: true,
-    filterBy: {
-      providerMetadataIds
+/** @private
+ * Filter provider metadata that do not have any providers
+ */
+function filterProviderMetadataWithInvalidProviders (providerMetadataList, providerMetadataToProvidersMap) {
+  const filteredProviderMetadataList = []
+  for (const providerMetadata of providerMetadataList) {
+    const providerMetadataId = providerMetadata.id
+    if (providerMetadataToProvidersMap[providerMetadataId]?.length > 0) {
+      filteredProviderMetadataList.push(providerMetadata)
     }
-  })
-  const providers = providersHalModel._embedded.providers
-  const providerMetadataToProvidersMap = providers.reduce((providerMetadataToProvidersMap, provider) => {
-    providerMetadataToProvidersMap[provider.provider_metadata] = providerMetadataToProvidersMap[provider.provider_metadata] || []
-    providerMetadataToProvidersMap[provider.provider_metadata].push({
-      id: provider.id,
-      label: provider.label,
-      description: provider.description,
-      provider_metadata: provider.provider_metadata,
-      eventmetadata: provider._embedded.eventmetadata
-    })
-    return providerMetadataToProvidersMap
-  }, [])
+  }
+  return filteredProviderMetadataList
+}
+
+/** @private */
+function getProviderMetadataToProvidersMap (consumerId, eventsClient, allProvidersForOrgList) {
+  const providerMetadataToProvidersMap = {}
+  for (const provider of allProvidersForOrgList) {
+    if (provider._embedded?.eventmetadata?.length > 0) {
+      providerMetadataToProvidersMap[provider.provider_metadata] = providerMetadataToProvidersMap[provider.provider_metadata] || []
+      providerMetadataToProvidersMap[provider.provider_metadata].push({
+        id: provider.id,
+        label: provider.label,
+        description: provider.description,
+        provider_metadata: provider.provider_metadata,
+        eventmetadata: provider._embedded.eventmetadata
+      })
+    }
+  }
   return providerMetadataToProvidersMap
 }
 

--- a/lib/events/ProviderHelper.js
+++ b/lib/events/ProviderHelper.js
@@ -9,6 +9,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+async function getAllEntitledProvidersForOrg (eventsClient, consumerId) {
+  const providerCollectionHalModels = await eventsClient.getAllProviders(consumerId, { fetchEventMetadata: true })
+  return providerCollectionHalModels._embedded.providers
+}
+
 async function selectProviderForProviderMetadata (providerMetadataToProvidersMap,
   providerMetadata, obj) {
   const providerChoices = []
@@ -64,6 +69,7 @@ async function selectEventMetadataForProvider (providerSelected, eventMetadataCh
 }
 
 module.exports = {
+  getAllEntitledProvidersForOrg,
   selectProviderForProviderMetadata,
   selectEventMetadataForProvider
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
**Old workflow**
Fetch all entitled provider metadata for org - L1
After user selects the provider metadata they want to subscribe to from L1 - PM
Fetch all entitled provider for org filtered by PM -L2 ( some provider metadata may not have provider, some providers may not have valid event metadata ) 
This resulted in not having any providers to choose from for certain provider metadata, which is a bad experience. 

**New workflow:**
Fetch all entitled provider metadata for org - L1
Fetch all entitled provider for org - L2
Filter providers that do not have valid event metadata and create map of provider metadata to providers list - M1
Filter provider metadata from L1 that do not have any valid providers in M1 - L3

user selects the provider metadata they want to subscribe to from L3 
for the selected provider metadata there is guaranteed to be valid providers and associated event metadata

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
