### PR TITLE
fix(breaking-change): ACNA-3718 - remove @openwhisk/wskdebug from the default action generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -135,8 +135,9 @@ Note: characters can only be split by '-'.
     if (options.dependencies) {
       utils.addDependencies(this, options.dependencies)
     }
-    // make sure wskdebug is there
-    utils.addDependencies(this, { '@openwhisk/wskdebug': '^1.3.0', ...options.devDependencies }, true)
+    if (options.devDependencies) {
+      utils.addDependencies(this, options.devDependencies, true)
+    }
     // make sure the node engines are added
     this.addPackageJsonNodeEngines()
   }

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -181,6 +181,7 @@ Note: characters can only be split by '-'.
       utils.readPackageJson.mockReturnValue({})
       utils.readYAMLConfig.mockReturnValue({})
 
+      // third parameter options is {} by default here
       actionGenerator.addAction('myAction', './templateFile.js')
 
       // 1. test copy action template to right destination
@@ -192,9 +193,8 @@ Note: characters can only be split by '-'.
         'runtimeManifest',
         // function path should be checked to be relative to config file
         { packages: { 'dx-excshell-1': { actions: { myAction: { annotations: { 'require-adobe-auth': true }, function: expect.stringContaining('myAction/index.js'), runtime: constants.defaultRuntimeKind, web: 'yes' } }, license: 'Apache-2.0' } } })
-
-      // 3. make sure wskdebug dev dependency was added to package.json
-      expect(utils.addDependencies).toHaveBeenCalledWith(actionGenerator, { '@openwhisk/wskdebug': expect.any(String) }, true)
+      // dev or prod
+      expect(utils.addDependencies).not.toHaveBeenCalled()
     })
 
     test('with extra dependencies and manifest already exists', () => {
@@ -226,13 +226,13 @@ Note: characters can only be split by '-'.
       // 3. make sure wskdebug dev dependency was added to package.json
       // prod
       expect(utils.addDependencies).toHaveBeenCalledWith(actionGenerator, {
-        abc: '1.2.3', def: '4.5.6'
+        abc: '1.2.3',
+        def: '4.5.6'
       })
       // dev
       expect(utils.addDependencies).toHaveBeenCalledWith(actionGenerator, {
         xyz: '3.2.1',
-        vuw: '6.5.4',
-        '@openwhisk/wskdebug': expect.any(String)
+        vuw: '6.5.4'
       }, true)
     })
 


### PR DESCRIPTION
We are using the app-dev plugin for local debugging now. 
See also: https://github.com/adobe/aio-cli-plugin-app/pull/854

This is a `BREAKING CHANGE` so it requires a major version update.

Unfortunately, it has [28 dependents](https://www.npmjs.com/package/@adobe/generator-app-common-lib?activeTab=dependents) - so those dependents will need to update their version of common lib **IF** they use the `addAction` functionality. Ideally we update everything.

Start with https://github.com/adobe/generator-aio-app/blob/420490da23ac758cdcf5c5556781ef963850263a/package.json#L51C1-L61C43
 
## How Has This Been Tested?

- npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
