### PR TITLE
feat: ACNA-4515 add pr-reviewer workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,62 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    # NOTE: comment body matching is exact — /review or /pr-reviewer with no trailing spaces, newlines, or mixed case
+    # This does not fail the workflow; non-matching comments simply do not trigger the job
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       (github.event.comment.body == '/review' || github.event.comment.body == '/pr-reviewer'))
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.gate.outputs.allowed }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+    steps:
+      - name: Gate check
+        id: gate
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          else
+            # Fall back to "none" if user is not a collaborator (gh api returns 404) so allowed=false is output cleanly
+            PERM=$(gh api repos/$GITHUB_REPOSITORY/collaborators/$COMMENT_USER_LOGIN/permission --jq '.permission' 2>/dev/null || echo "none")
+            # Intentionally require admin or maintain; write collaborators are excluded to
+            # limit who can trigger potentially expensive/sensitive review automation.
+            if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
+              DATA=$(gh api repos/$GITHUB_REPOSITORY/pulls/$ISSUE_NUMBER)
+              echo "allowed=true" >> $GITHUB_OUTPUT
+              echo "pr_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+              echo "head_sha=$(echo "$DATA" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
+            else
+              echo "allowed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # GITHUB_REPOSITORY is set automatically by GitHub Actions (owner/repo)
+
+  review:
+    needs: check
+    if: needs.check.outputs.allowed == 'true'
+    uses: adobe/aio-reusable-workflows/.github/workflows/pr-review.yml@main
+    with:
+      pr_number: ${{ needs.check.outputs.pr_number }}
+      head_sha: ${{ needs.check.outputs.head_sha }}
+    secrets:
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.APP_BUILDER_AWS_BEARER_TOKEN_BEDROCK }}


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->
Adds an AI-powered PR reviewer workflow that automatically reviews pull requests using Claude via AWS Bedrock. Triggers on PR open/reopen/synchronize and on /review or /pr-reviewer comments by admins or maintainers.
## Related Issue
https://jira.corp.adobe.com/browse/ACNA-4515
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Reduces code review toil by providing automated first-pass reviews with inline suggestions. Part of a broader rollout across App Builder repos.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested end-to-end in adobe/generator-aio-app — workflow triggers correctly on PR events and /review comments, posts inline suggestions and summary reviews via github-actions[bot].
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
