### PR TITLE
feat: ACNA-4537 add dependabot coverage upload workflow

### DIFF
--- a/.github/workflows/dependabot-coverage-upload.yml
+++ b/.github/workflows/dependabot-coverage-upload.yml
@@ -1,0 +1,33 @@
+name: Dependabot Coverage Upload
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    if: github.event.issue.pull_request != null && github.event.comment.body == '/upload-coverage'
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.gate.outputs.allowed }}
+    steps:
+      - name: Gate check
+        id: gate
+        run: |
+          set -euo pipefail
+          PERM=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$COMMENT_USER_LOGIN/permission" --jq '.permission' 2>/dev/null || echo "none")
+          if [ "$PERM" = "admin" ] || [ "$PERM" = "maintain" ]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
+
+  upload:
+    needs: check
+    if: needs.check.outputs.allowed == 'true'
+    uses: adobe/aio-reusable-workflows/.github/workflows/dependabot-coverage-upload.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixes the reusable dependabot-coverage-upload.yml workflow so Codecov correctly processes coverage reports uploaded via the /upload-coverage admin comment trigger on Dependabot PRs. Previously every upload was marked "Unusable report".

Three root causes fixed:

Missing actions/checkout: Codecov embeds a local file listing in the upload payload to map SF: paths in lcov; without source files present the report is always unusable
Artifact pattern included Windows runs — Windows lcov uses backslash paths (SF:src\auth.js) that Codecov cannot resolve against the repo; narrowed to ubuntu-latest only
Missing override_pr / override_commit — Codecov was not associating the upload with the correct Dependabot PR
Also aligns the startswith() filter in "Find original CI run" with the download pattern to prevent false "artifact not found" comments.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACNA-4537](https://jira.corp.adobe.com/browse/ACNA-4537)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When Dependabot opens a PR, GitHub restricts secret access so CODECOV_TOKEN is unavailable and the normal upload in node.js.yml is skipped. Coverage artifacts are saved instead, and an admin triggers re-upload via /upload-coverage comment. This PR makes that re-upload actually work.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested end-to-end on adobe/aio-e2e-tests using the dependabot-codecov-fix branch (which aio-e2e-tests calls):

Commented /upload-coverage as an admin on a Dependabot PR
Confirmed Codecov successfully processed the report (no "Unusable report", coverage % shown)
Confirmed Codecov posted a coverage comment on the PR

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
